### PR TITLE
Add support for Fedora netinst ISOs

### DIFF
--- a/grub2/inc-fedora.cfg
+++ b/grub2/inc-fedora.cfg
@@ -5,16 +5,22 @@ function add_menu {
   regexp \
     --set 1:isoname \
     --set 2:variant \
-    --set 3:arch \
-    --set 4:version \
-    "^${isopath}/fedora/(Fedora-([^-]+)-Live-([^-]+)-([^-]+)-[^-]+\.iso)\$" "${isofile}"
-  menuentry "Fedora ${version} ${arch} ${variant}" "${isofile}" "${isoname}" --class fedora {
+    --set 3:purpose \
+    --set 4:arch \
+    --set 5:version \
+    "^${isopath}/fedora/(Fedora-([^-]+)-(Live|netinst)-([^-]+)-([^-]+)-[^-]+\.iso)\$" "${isofile}"
+  menuentry "Fedora ${version} ${arch} ${variant} ${purpose}" "${isofile}" "${isoname}" "${purpose}" --class fedora {
     set isofile=$2
     set isoname=$3
+    set purpose=$4
     use "${isoname}"
     loop $isofile
     probe --set isolabel --label (loop)
-    linux (loop)/images/pxeboot/vmlinuz root=live:CDLABEL=${isolabel} rd.live.image iso-scan/filename=${isofile}
+    if [ "${purpose}" == 'netinst' ]; then
+      linux (loop)/images/pxeboot/vmlinuz inst.stage2=hd:LABEL=${isolabel} iso-scan/filename=${isofile}
+    else
+      linux (loop)/images/pxeboot/vmlinuz root=live:CDLABEL=${isolabel} rd.live.image iso-scan/filename=${isofile}
+    fi
     initrd (loop)/images/pxeboot/initrd.img
   }
 }


### PR DESCRIPTION
As well as live ISOs, Fedora provides "netinst" ISOs (smaller ISOs where the installer pulls packages from the internet during install). These require slightly different boot parameters from the live ISOs currently supported by GLIM.

This PR infers whether the ISO is a netinst or a live ISO from its filename, and supplies the appropriate boot parameters.