### PR TITLE
Fix antiX

### DIFF
--- a/grub2/grub.cfg
+++ b/grub2/grub.cfg
@@ -145,7 +145,7 @@ if any_exists ${isopath}/almalinux/AlmaLinux-*-Live-*.iso; then
   }
 fi
 
-if any_exists ${isopath}/antix/antiX-*-full.iso; then
+if any_exists ${isopath}/antix/antiX-*.iso; then
   menuentry "antiX >" --class antix {
     configfile "${prefix}/inc-antix.cfg"
   }


### PR DESCRIPTION
Inconsistency in grub2/grub.cfg caused antiX entry to not appear if not using full antiX ISO.